### PR TITLE
Locking events

### DIFF
--- a/migrations/20240820062611_locking_events.down.sql
+++ b/migrations/20240820062611_locking_events.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE public.events DROP COLUMN is_locked;

--- a/migrations/20240820062611_locking_events.up.sql
+++ b/migrations/20240820062611_locking_events.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TABLE public.events ADD COLUMN is_locked BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -31,6 +31,7 @@ pub struct FormEvent {
     pub location: String,
     pub teacher: String,
     pub info: String,
+    pub is_locked: bool,
 }
 
 #[derive(Deserialize)]

--- a/src/routes/add_event.rs
+++ b/src/routes/add_event.rs
@@ -52,6 +52,7 @@ async fn post_add_event_form(
         location,
         teacher,
         info,
+        is_locked
     }): Form<FormEvent>,
 ) -> Result<impl IntoResponse, VentError> {
     let date = NaiveDateTime::parse_from_str(&date, "%Y-%m-%dT%H:%M").context(ParseTimeSnafu {
@@ -64,15 +65,16 @@ async fn post_add_event_form(
     let id = sqlx::query!(
         r#"
 INSERT INTO public.events
-(event_name, "date", "location", teacher, other_info)
-VALUES($1, $2, $3, $4, $5)
+(event_name, "date", "location", teacher, other_info, is_locked)
+VALUES($1, $2, $3, $4, $5, $6)
 RETURNING id
         "#,
         name,
         date,
         location,
         teacher,
-        info
+        info,
+        is_locked
     )
     .fetch_one(&mut *state.get_connection().await?) //add the event to the db
     .await

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -82,6 +82,7 @@ pub fn update_calendar_thread(
             teacher,
             other_info,
             zip_file: _,
+            is_locked: _
         } in sqlx::query_as!(DbEvent, r#"SELECT * FROM events"#)
             .fetch_all(&mut *conn)
             .await

--- a/src/routes/index.rs
+++ b/src/routes/index.rs
@@ -23,6 +23,7 @@ pub async fn get_index(
         pub location: String,
         pub teacher: String,
         pub other_info: String,
+        pub is_locked: bool,
     }
 
     impl<'a> From<(DbEvent, &'a str)> for HTMLEvent {
@@ -36,6 +37,7 @@ pub async fn get_index(
                     teacher,
                     other_info,
                     zip_file: _,
+                    is_locked
                 },
                 fmt,
             ): (DbEvent, &'a str),
@@ -47,6 +49,7 @@ pub async fn get_index(
                 location,
                 teacher,
                 other_info: other_info.unwrap_or_default(),
+                is_locked
             }
         }
     }

--- a/src/routes/update_events.rs
+++ b/src/routes/update_events.rs
@@ -41,6 +41,7 @@ async fn get_update_event(
         teacher,
         other_info,
         zip_file: _,
+        is_locked
     } = sqlx::query_as!(
         DbEvent,
         r#"

--- a/src/routes/update_events.rs
+++ b/src/routes/update_events.rs
@@ -328,7 +328,8 @@ WHERE event_id = $1
                 "date": date.to_string(),
                 "location": location,
                 "teacher": teacher,
-                "other_info": other_info.unwrap_or_default()
+                "other_info": other_info.unwrap_or_default(),
+                "is_locked": is_locked
             }),
         "existing_prefects": existing_prefects,
         "existing_participants": existing_participants,
@@ -352,6 +353,7 @@ async fn post_update_event(
         location,
         teacher,
         info,
+        is_locked
     }): Form<FormEvent>,
 ) -> Result<impl IntoResponse, VentError> {
     let date = NaiveDateTime::parse_from_str(&date, "%Y-%m-%dT%H:%M").context(ParseTimeSnafu {
@@ -362,7 +364,7 @@ async fn post_update_event(
     sqlx::query!(
         r#"
 UPDATE public.events
-SET event_name=$2, date=$3, location=$4, teacher=$5, other_info=$6
+SET event_name=$2, date=$3, location=$4, teacher=$5, other_info=$6, is_locked=$7
 WHERE id=$1
         "#,
         event_id,
@@ -370,7 +372,8 @@ WHERE id=$1
         date,
         location,
         teacher,
-        info
+        info,
+        is_locked
     )
     .execute(&mut *state.get_connection().await?)
     .await

--- a/src/state/db_objects.rs
+++ b/src/state/db_objects.rs
@@ -79,6 +79,7 @@ pub struct DbEvent {
     pub other_info: Option<String>,
     #[allow(dead_code)]
     pub zip_file: Option<String>,
+    pub is_locked: bool,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/www/add_event.liquid
+++ b/www/add_event.liquid
@@ -60,6 +60,8 @@
                         placeholder="Theme: SCAN">
             </div>
 
+            <input type="hidden" name="is_locked" value="false">
+
             <button type="submit" class="btn btn-primary">Add new Event.</button>
         </form>
     </div>

--- a/www/update_event.liquid
+++ b/www/update_event.liquid
@@ -79,6 +79,29 @@
                 {% endunless %}>
       </div>
 
+      <div class="mb-3">
+        {% if auth.permissions["edit_events"] %}
+          <div class="form-check">
+            <input class="form-check-input" type="radio" name="is_locked" id="is_locked" value="true"
+              {% if event.is_locked %} checked {% endif %}
+            >
+            <label class="form-check-label" for="is_locked">Locked</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="radio" name="is_locked" id="is_unlocked" value="false"
+                    {% unless event.is_locked %} checked {% endunless %}
+            >
+            <label class="form-check-label" for="is_unlocked">Unlocked</label>
+          </div>
+        {% else %}
+          {% if event.is_locked %}
+            <p>Event is locked</p>
+          {% else %}
+            <p>Event is unlocked</p>
+          {% endif %}
+        {% endif %}
+      </div>
+
       {% if auth.permissions["edit_events"] %}
       <button
               type="submit"
@@ -100,9 +123,10 @@
 
 <br>
 
+
 {% if auth.is_logged_in %}
 
-  {% if auth.permissions["add_rm_self_to_event"] %}
+  {% if auth.permissions["add_rm_self_to_event"] and event.is_locked == false %}
     <div class="card">
       <div class="card-body">
         {% if auth.permissions["edit_participants_on_events"] or already_in.past_date != true %}
@@ -194,7 +218,7 @@
 
               </form>
             {% endif %}
-            {% if auth.permissions["edit_participants_on_events"] %}
+            {% if auth.permissions["edit_participants_on_events"] and event.is_locked == false %}
 
 
               <h5>Participants</h5>


### PR DESCRIPTION
Add a big button to lock events.
People who can edit events can lock & unlock events.
No participants can be added to locked events, ideal for events which all people participate in and don't require house points.