### PR TITLE
House points for victory?

### DIFF
--- a/migrations/20240823080745_house_points_for_winning.down.sql
+++ b/migrations/20240823080745_house_points_for_winning.down.sql
@@ -1,0 +1,3 @@
+-- Add down migration script here
+
+ALTER TABLE public.events DROP COLUMN extra_points;

--- a/migrations/20240823080745_house_points_for_winning.up.sql
+++ b/migrations/20240823080745_house_points_for_winning.up.sql
@@ -1,0 +1,3 @@
+-- Add up migration script here
+
+ALTER TABLE public.events ADD COLUMN extra_points INTEGER NOT NULL DEFAULT 0;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -32,6 +32,7 @@ pub struct FormEvent {
     pub teacher: String,
     pub info: String,
     pub is_locked: bool,
+    pub victory_points: i32,
 }
 
 #[derive(Deserialize)]

--- a/src/routes/add_event.rs
+++ b/src/routes/add_event.rs
@@ -52,6 +52,7 @@ async fn post_add_event_form(
         teacher,
         info,
         is_locked,
+        victory_points: _
     }): Form<FormEvent>,
 ) -> Result<impl IntoResponse, VentError> {
     let date = NaiveDateTime::parse_from_str(&date, "%Y-%m-%dT%H:%M").context(ParseTimeSnafu {

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -87,6 +87,7 @@ pub fn update_calendar_thread(
             other_info,
             zip_file: _,
             is_locked: _,
+            extra_points: _,
         } in sqlx::query_as!(DbEvent, r#"SELECT * FROM events"#)
             .fetch_all(&mut *conn)
             .await

--- a/src/routes/index.rs
+++ b/src/routes/index.rs
@@ -38,6 +38,7 @@ pub async fn get_index(
                     other_info,
                     zip_file: _,
                     is_locked,
+                    extra_points: _
                 },
                 fmt,
             ): (DbEvent, &'a str),

--- a/src/routes/index.rs
+++ b/src/routes/index.rs
@@ -20,10 +20,6 @@ pub async fn get_index(
         pub id: i32,
         pub event_name: String,
         pub date: String,
-        pub location: String,
-        pub teacher: String,
-        pub other_info: String,
-        pub is_locked: bool,
     }
 
     impl<'a> From<(DbEvent, &'a str)> for HTMLEvent {
@@ -33,11 +29,11 @@ pub async fn get_index(
                     id,
                     event_name,
                     date,
-                    location,
-                    teacher,
-                    other_info,
+                    location: _,
+                    teacher: _,
+                    other_info: _,
                     zip_file: _,
-                    is_locked,
+                    is_locked: _,
                     extra_points: _
                 },
                 fmt,
@@ -47,10 +43,6 @@ pub async fn get_index(
                 id,
                 event_name,
                 date: date.to_env_string(fmt),
-                location,
-                teacher,
-                other_info: other_info.unwrap_or_default(),
-                is_locked,
             }
         }
     }

--- a/src/routes/update_events.rs
+++ b/src/routes/update_events.rs
@@ -41,6 +41,7 @@ async fn get_update_event(
         other_info,
         zip_file: _,
         is_locked,
+        extra_points
     } = sqlx::query_as!(
         DbEvent,
         r#"

--- a/src/routes/update_events.rs
+++ b/src/routes/update_events.rs
@@ -330,7 +330,8 @@ WHERE event_id = $1
                 "location": location,
                 "teacher": teacher,
                 "other_info": other_info.unwrap_or_default(),
-                "is_locked": is_locked
+                "is_locked": is_locked,
+                "victory_points": extra_points
             }),
         "existing_prefects": existing_prefects,
         "existing_participants": existing_participants,
@@ -354,6 +355,7 @@ async fn post_update_event(
         teacher,
         info,
         is_locked,
+        victory_points
     }): Form<FormEvent>,
 ) -> Result<impl IntoResponse, VentError> {
     let date = NaiveDateTime::parse_from_str(&date, "%Y-%m-%dT%H:%M").context(ParseTimeSnafu {
@@ -364,7 +366,7 @@ async fn post_update_event(
     sqlx::query!(
         r#"
 UPDATE public.events
-SET event_name=$2, date=$3, location=$4, teacher=$5, other_info=$6, is_locked=$7
+SET event_name=$2, date=$3, location=$4, teacher=$5, other_info=$6, is_locked=$7, extra_points=$8
 WHERE id=$1
         "#,
         event_id,
@@ -373,7 +375,8 @@ WHERE id=$1
         location,
         teacher,
         info,
-        is_locked
+        is_locked,
+        victory_points
     )
     .execute(&mut *state.get_connection().await?)
     .await

--- a/src/state/db_objects.rs
+++ b/src/state/db_objects.rs
@@ -80,6 +80,7 @@ pub struct DbEvent {
     #[allow(dead_code)]
     pub zip_file: Option<String>,
     pub is_locked: bool,
+    pub extra_points: i32,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/www/add_event.liquid
+++ b/www/add_event.liquid
@@ -61,6 +61,7 @@
             </div>
 
             <input type="hidden" name="is_locked" value="false">
+            <input type="hidden" name="victory_points" value="0">
 
             <button type="submit" class="btn btn-primary">Add new Event.</button>
         </form>

--- a/www/show_people.liquid
+++ b/www/show_people.liquid
@@ -1,7 +1,11 @@
 {% include "partials/header.liquid" %}
 
+<div class="alert alert-light" role="alert">
+    <p>Total House Points: {{ total_house_points }}</p>
+</div>
 
 {% if auth.is_logged_in %}
+    <br>
     <h2>People</h2>
 
     <table class="table">

--- a/www/show_people.liquid
+++ b/www/show_people.liquid
@@ -1,7 +1,8 @@
 {% include "partials/header.liquid" %}
 
 <div class="alert alert-light" role="alert">
-    <p>Total House Points: {{ total_house_points }}</p>
+    <p>Participation Points: {{ participation_points }}</p>
+    <p>Victory Points: {{ event_victory_points }}</p>
 </div>
 
 {% if auth.is_logged_in %}

--- a/www/update_event.liquid
+++ b/www/update_event.liquid
@@ -79,6 +79,12 @@
                 {% endunless %}>
       </div>
 
+      <div class="input-group mb-3">
+        <label for="victory_points" class="input-group-text">Points from Victory:</label>
+        <input type="text" id="victory_points" name="victory_points" class="form-control" value="{{ event.victory_points }}"
+          {% unless auth.permissions["edit_events"] %} disabled {% endunless %}>
+      </div>
+
       <div class="mb-3">
         {% if auth.permissions["edit_events"] %}
           <div class="form-check">


### PR DESCRIPTION
This allows people with edit perms to add house points to the house total if the house wins an event. 

I could've gone with a 1st 2nd 3rd system, but this way means that certain events can be worth more and I don't have to worry about ties etc.

@Genau6502 do you want me to try to build in a way to disable this? It shouldn't be too bad - I can just do something similar to the other bits where it just doesn't appear in the frontend any more.